### PR TITLE
Addition of Pipeline-Accordant Logger

### DIFF
--- a/lib/tyrano_dsl/export_dsl/context.rb
+++ b/lib/tyrano_dsl/export_dsl/context.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 require_relative 'export_dsl'
 require_relative '../file_actions/file_copy'
 require_relative '../file_actions/create_file'
@@ -13,7 +11,7 @@ class TyranoDsl::ExportDsl::Context
   attr_reader :file_actions
 
   def initialize(world)
-    @logger = Logger.new(STDOUT)
+    @logger = TyranoDsl::Logger.new
     @world = world
     @file_actions = []
     @current_scene_content = nil

--- a/lib/tyrano_dsl/export_dsl/main.rb
+++ b/lib/tyrano_dsl/export_dsl/main.rb
@@ -4,7 +4,7 @@ require_relative 'context'
 class TyranoDsl::ExportDsl::Main
 
   def initialize
-    @logger = Logger.new(STDOUT)
+    @logger = TyranoDsl::Logger.new
     @words = {}
     TyranoDsl::Vocabulary.get_words_class('export_dsl/words') do |word, word_class|
       @words[word] = word_class.new

--- a/lib/tyrano_dsl/export_tyrano/context.rb
+++ b/lib/tyrano_dsl/export_tyrano/context.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require 'set'
 
 require_relative 'writers/scene'
@@ -27,7 +26,7 @@ class TyranoDsl::ExportTyrano::Context
 
   # @param [TyranoDsl::Elements::World] world
   def initialize(world)
-    @logger = Logger.new(STDOUT)
+    @logger = TyranoDsl::Logger.new
     @world = world
 
     @file_actions = []

--- a/lib/tyrano_dsl/export_tyrano/main.rb
+++ b/lib/tyrano_dsl/export_tyrano/main.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 require_relative '../tyrano_dsl'
 require_relative '../vocabulary'
 require_relative 'writers/background'
@@ -13,7 +11,7 @@ require_relative 'context'
 class TyranoDsl::ExportTyrano::Main
 
   def initialize
-    @logger = Logger.new(STDOUT)
+    @logger = TyranoDsl::Logger.new
     @words = {}
     TyranoDsl::Vocabulary.get_words_class('export_tyrano/words') do |word, word_class|
       @words[word] = word_class.new

--- a/lib/tyrano_dsl/export_tyrano/writers/base_writer.rb
+++ b/lib/tyrano_dsl/export_tyrano/writers/base_writer.rb
@@ -10,7 +10,7 @@ class TyranoDsl::ExportTyrano::Writers::BaseWriter
   end
 
   def logger
-    @logger ||= Logger.new(STDOUT)
+    @logger ||= TyranoDsl::Logger.new
   end
 
   def log

--- a/lib/tyrano_dsl/file_actions/base_file_action.rb
+++ b/lib/tyrano_dsl/file_actions/base_file_action.rb
@@ -1,4 +1,3 @@
-require 'logger'
 require_relative 'files_actions'
 
 class TyranoDsl::FileActions::BaseFileAction
@@ -21,7 +20,7 @@ class TyranoDsl::FileActions::BaseFileAction
   end
 
   def logger
-    @logger ||= Logger.new(STDOUT)
+    @logger ||= TyranoDsl::Logger.new
   end
 
   def log

--- a/lib/tyrano_dsl/import_dsl/parser.rb
+++ b/lib/tyrano_dsl/import_dsl/parser.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 require_relative '../parsed_word'
 require_relative '../tyrano_exception'
 require_relative '../vocabulary'
@@ -46,7 +44,7 @@ class TyranoDsl::ImportDsl::Parser
   # @param [String] initial_file_path
   def initialize(context, initial_file_path)
     @context = context
-    @logger = Logger.new(STDOUT)
+    @logger = TyranoDsl::Logger.new
     @included_files_hierarchy = [initial_file_path]
   end
 

--- a/lib/tyrano_dsl/import_tyrano/readers/base_reader.rb
+++ b/lib/tyrano_dsl/import_tyrano/readers/base_reader.rb
@@ -1,5 +1,3 @@
-require 'logger'
-
 require_relative 'readers'
 
 class TyranoDsl::ImportTyrano::Readers::BaseReader
@@ -7,7 +5,7 @@ class TyranoDsl::ImportTyrano::Readers::BaseReader
   protected
 
   def logger
-    @logger ||= Logger.new(STDOUT)
+    @logger ||= TyranoDsl::Logger.new
   end
 
   def log

--- a/lib/tyrano_dsl/intermediate/main.rb
+++ b/lib/tyrano_dsl/intermediate/main.rb
@@ -22,7 +22,7 @@ class TyranoDsl::Intermediate::Main
   ]
 
   def initialize
-    @logger = Logger.new(STDOUT)
+    @logger = TyranoDsl::Logger.new
     @words = {}
     TyranoDsl::Vocabulary.get_words_class('intermediate/words') do |word, word_class|
       @words[word] = word_class.new

--- a/lib/tyrano_dsl/logger.rb
+++ b/lib/tyrano_dsl/logger.rb
@@ -1,0 +1,45 @@
+require 'logger'
+require_relative 'tyrano_dsl'
+
+class TyranoDsl::Logger
+
+  UNKNOWN = ::Logger::UNKNOWN
+  FATAL = ::Logger::FATAL
+  ERROR = ::Logger::ERROR
+  WARN = ::Logger::WARN
+  INFO = ::Logger::INFO
+  DEBUG = ::Logger::DEBUG
+
+  # @param on_high_severity [IO | nil] a pipeline or file descriptor, default to `STDERR`
+  # @param on_low_severity [IO | nil] a pipeline or file descriptor, default to `STDOUT`
+  # @return [Logger]
+  def initialize(on_high_severity: nil, on_low_severity: nil)
+    @high_severity_logger = ::Logger.new(on_high_severity || STDERR)
+    @low_severity_logger = ::Logger.new(on_low_severity || STDOUT)
+  end
+
+  # See standard library's `Logger.fatal`
+  def fatal(...)
+    @high_severity_logger.fatal(...)
+  end
+
+  # See standard library's `Logger.error`
+  def error(...)
+    @high_severity_logger.error(...)
+  end
+
+  # See standard library's `Logger.warn`
+  def warn(...)
+    @high_severity_logger.warn(...)
+  end
+
+  # See standard library's `Logger.info`
+  def info(...)
+    @low_severity_logger.info(...)
+  end
+
+  # See standard library's `Logger.debug`
+  def debug(...)
+    @low_severity_logger.debug(...)
+  end
+end

--- a/lib/tyrano_dsl/main.rb
+++ b/lib/tyrano_dsl/main.rb
@@ -1,6 +1,7 @@
 require_relative 'tyrano_exception'
 require_relative 'tyrano_dsl'
 require_relative 'intermediate/main'
+require_relative 'logger'
 
 # The entry point
 class TyranoDsl::Main


### PR DESCRIPTION
Replaced the built-in logging utility with a pipeline accordant logging utility.

Logging a debug or info level message can appear in the standard output stream,
but logging a warn, error or critical level message can appear in the standard error stream.
In fact, several programming languages like Python, JavaScript and MATLAB give color
to every warning and error message.

I believe that it is better to put warning messages in the standard error.

- Add pipeline-accordant logger
- Replace built-in `logger`
